### PR TITLE
feat: update version check for component support and jukebox listener

### DIFF
--- a/src/main/java/zone/vao/nexoAddon/NexoAddon.java
+++ b/src/main/java/zone/vao/nexoAddon/NexoAddon.java
@@ -83,7 +83,7 @@ public final class NexoAddon extends JavaPlugin {
   }
 
   private void checkComponentSupport() {
-    componentSupport = VersionUtil.isVersionLessThan("1.21.2");
+    componentSupport = VersionUtil.isVersionLessThan("1.21.3");
   }
 
   private void initializeCommandManager() {

--- a/src/main/java/zone/vao/nexoAddon/events/playerInteracts/JukeboxPlayableListener.java
+++ b/src/main/java/zone/vao/nexoAddon/events/playerInteracts/JukeboxPlayableListener.java
@@ -23,7 +23,7 @@ import zone.vao.nexoAddon.utils.VersionUtil;
 public class JukeboxPlayableListener {
 
   public static void onJukeboxPlayable(final PlayerInteractEvent event) {
-    if (!VersionUtil.isVersionLessThan("1.21")) return;
+    if (!VersionUtil.isVersionLessThan("1.21.1")) return;
 
     Player player = event.getPlayer();
     if (!isValidInteraction(event)) return;


### PR DESCRIPTION
Updated the version checking of the component support and jukebox listener. The component support now checks if the version is less than "1.21.3" instead of "1.21.2". Similarly, the jukebox listener now checks if the version is less than "1.21.1" instead of "1.21".