### PR TITLE
1.2.10

### DIFF
--- a/src/main/java/zone/vao/nexoAddon/classes/populators/orePopulator/CustomOrePopulator.java
+++ b/src/main/java/zone/vao/nexoAddon/classes/populators/orePopulator/CustomOrePopulator.java
@@ -79,8 +79,10 @@ public class CustomOrePopulator extends BlockPopulator {
   private void placeBlock(PlacementPosition position, Ore ore, WorldInfo worldInfo, LimitedRegion limitedRegion, boolean isAbove) {
     if (ore.getNexoBlocks() != null && ore.getNexoBlocks().getBlockData() != null) {
       if(ore.isTall()) {
-        limitedRegion.setBlockData(position.x(), position.y()+1, position.z(), ore.getNexoBlocks().getBlockData());
-        limitedRegion.setBlockData(position.x(), position.y(), position.z(), Material.TRIPWIRE.createBlockData());
+        limitedRegion.setBlockData(position.x(), position.y(), position.z(), ore.getNexoBlocks().getBlockData());
+        World world = Bukkit.getWorld(worldInfo.getUID());
+        if(limitedRegion.getType(new Location(world, position.x(), position.y()+1, position.z())).isAir())
+          limitedRegion.setBlockData(position.x(), position.y()+1, position.z(), Material.TRIPWIRE.createBlockData());
       }else{
         limitedRegion.setBlockData(position.x(), position.y(), position.z(), ore.getNexoBlocks().getBlockData());
       }

--- a/src/main/java/zone/vao/nexoAddon/events/furnitureBreaks/BreakDoubleHit.java
+++ b/src/main/java/zone/vao/nexoAddon/events/furnitureBreaks/BreakDoubleHit.java
@@ -17,6 +17,8 @@ public class BreakDoubleHit {
 
     if(!NexoAddon.getInstance().getGlobalConfig().getBoolean("double_hit_destroy_mechanic", true)) return;
 
+    event.getMechanic().getHitbox().refreshHitboxes(event.getBaseEntity(), event.getMechanic());
+
     UUID playerId = event.getPlayer().getUniqueId();
     UUID furnitureId = event.getBaseEntity().getUniqueId();
 
@@ -24,7 +26,6 @@ public class BreakDoubleHit {
 
     if (lastHit == null || !lastHit.getFurniture().equals(furnitureId)
         || (lastHit.getTimestamp() + TIMEFRAME) < System.currentTimeMillis()) {
-      event.getMechanic().getHitbox().refreshHitboxes(event.getBaseEntity(), event.getMechanic());
       lastHits.put(playerId, new FurnitureTimestamp(furnitureId));
       event.setCancelled(true);
     } else {


### PR DESCRIPTION
feat(CustomOrePopulator): improve block placement for tall ores
This commit improves the way blocks are placed for tall ores in the CustomOrePopulator class. Previously, the block data was simply set without checking if the location above was air. Now, we first check if the location above is air before setting the block. This will prevent the placement of blocks in inappropriate locations.