### PR TITLE
feat: added support for custom biomes in ore populators without the use of NMS

### DIFF
--- a/src/main/java/zone/vao/nexoAddon/utils/PopulatorsConfigUtil.java
+++ b/src/main/java/zone/vao/nexoAddon/utils/PopulatorsConfigUtil.java
@@ -5,10 +5,7 @@ import com.nexomc.nexo.api.NexoFurniture;
 import com.nexomc.nexo.mechanics.custom_block.CustomBlockMechanic;
 import com.nexomc.nexo.mechanics.custom_block.stringblock.StringBlockMechanic;
 import com.nexomc.nexo.mechanics.furniture.FurnitureMechanic;
-import org.bukkit.Material;
-import org.bukkit.Registry;
-import org.bukkit.World;
-import org.bukkit.WorldCreator;
+import org.bukkit.*;
 import org.bukkit.block.Biome;
 import org.bukkit.configuration.ConfigurationSection;
 import org.bukkit.configuration.file.FileConfiguration;
@@ -267,13 +264,27 @@ public class PopulatorsConfigUtil {
   private List<Biome> parseBiomes(List<World> worlds, List<String> biomeNames) {
     List<Biome> availableBiomes = new ArrayList<>();
 
-    for (Biome biome : getAllBiomes()) {
-      if (biomeNames.contains(biome.name().toUpperCase().replace(" ", "_"))) {
+    Registry<Biome> biomeRegistry = Registry.BIOME;
+
+    for (String biomeName : biomeNames) {
+
+      NamespacedKey biomeKey;
+      if (biomeName.contains(":")) {
+        String[] parts = biomeName.split(":");
+        biomeKey = new NamespacedKey(parts[0], parts[1]);
+      } else {
+        biomeKey = NamespacedKey.minecraft(biomeName.toLowerCase());
+      }
+
+      Biome biome = biomeRegistry.get(biomeKey);
+      if (biome != null) {
         availableBiomes.add(biome);
+      } else {
+        NexoAddon.getInstance().getLogger().warning("Biome not found: " + biomeName);
       }
     }
 
-    return availableBiomes.isEmpty() ? getAllBiomes() : availableBiomes;
+    return availableBiomes.isEmpty() ? Registry.BIOME.stream().toList() : availableBiomes;
   }
 
   private List<Biome> getAllBiomes() {


### PR DESCRIPTION
EDIT: does not work on 1.21.1

### What's new 

- Added support for custom biomes in ore populators without using NMS.
- Should work fine with custom biomes from datapacks now.

### Why it matters

- No use of NMS = less breakage across versions. :3
- Custom biomes actually get ores now B)

### Notes

- Tested on 1.21.4 and it worked fine
- EDIT: Tested on 1.21.1 and it didn't work
- Also, IntelliJ did its usual auto-formatting and import cleanup :3


![image](https://github.com/user-attachments/assets/107cd37a-9745-4b05-8344-95542582bfe5)